### PR TITLE
Extract skybox-dev-base image and expand smoke test cleanup coverage

### DIFF
--- a/.devcontainer/ubuntu/Dockerfile
+++ b/.devcontainer/ubuntu/Dockerfile
@@ -10,10 +10,12 @@ COPY --chown=vscode:vscode crates/skybox/Cargo.toml crates/skybox/Cargo.toml
 COPY --chown=vscode:vscode crates/sarusctl/Cargo.toml crates/sarusctl/Cargo.toml
 COPY --chown=vscode:vscode crates/podman-driver/Cargo.toml crates/podman-driver/Cargo.toml
 COPY --chown=vscode:vscode crates/raster/Cargo.toml crates/raster/Cargo.toml
-RUN mkdir -p crates/skybox/src crates/sarusctl/src crates/podman-driver/src crates/raster/src && \
+RUN mkdir -p crates/skybox/src crates/sarusctl/src crates/sarusctl/tests crates/podman-driver/src crates/raster/src && \
     printf 'pub fn placeholder() {}\n' > crates/skybox/src/lib.rs && \
     printf 'pub fn placeholder() {}\n' > crates/sarusctl/src/lib.rs && \
     printf 'fn main() {}\n' > crates/sarusctl/src/main.rs && \
+    printf '#[test]\nfn placeholder() {}\n' > crates/sarusctl/tests/cli.rs && \
+    printf '#[test]\nfn placeholder() {}\n' > crates/sarusctl/tests/smoke.rs && \
     printf 'pub fn placeholder() {}\n' > crates/podman-driver/src/lib.rs && \
     printf 'pub fn placeholder() {}\n' > crates/raster/src/lib.rs
 
@@ -29,6 +31,7 @@ COPY --from=chef-planner --chown=vscode:vscode /workspaces/cluster-tooling/recip
 
 USER vscode
 RUN cargo chef cook --recipe-path recipe.json
+RUN cargo test --locked -p sarusctl --test cli --no-run
 RUN cargo chef cook --release --recipe-path recipe.json
 
 FROM base

--- a/.devcontainer/ubuntu/Dockerfile
+++ b/.devcontainer/ubuntu/Dockerfile
@@ -1,86 +1,8 @@
-FROM --platform=linux/amd64 ubuntu:24.04 AS base
-
-ENV DEBIAN_FRONTEND=noninteractive
-
-# can be set at build time with --build-arg SLURM_VERSION=24.05.8
-ARG SLURM_VERSION=""
-
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-      build-essential \
-      gcc g++ make \
-      pkg-config \
-      git \
-      clang llvm \
-      cmake \
-      python3 \
-      wget curl \
-      gawk \
-      bzip2 tar gzip \
-      which \
-      munge libmunge-dev \
-      hwloc libhwloc-dev \
-      libnuma-dev \
-      ca-certificates \
-    && rm -rf /var/lib/apt/lists/*
-
-RUN set -eux; \
-    if ! id -u vscode >/dev/null 2>&1; then \
-      groupadd -r vscode; \
-      useradd -m -s /bin/bash -g vscode vscode; \
-    fi; \
-    apt-get update && apt-get install -y --no-install-recommends sudo && rm -rf /var/lib/apt/lists/*; \
-    echo "vscode ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/99-vscode; \
-    chmod 0440 /etc/sudoers.d/99-vscode
-
-USER vscode
-ENV RUSTUP_HOME=/home/vscode/.rustup \
-    CARGO_HOME=/home/vscode/.cargo
-ENV PATH=/home/vscode/.cargo/bin:${PATH}
-
-RUN curl -fsSL https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain stable && \
-    cargo install cargo-chef --locked && \
-    rustc -V && cargo -V && cargo chef --version
-
-USER root
-RUN mkdir -p /opt/cargo-target && chown -R vscode:vscode /opt/cargo-target
-RUN mkdir -p /home/vscode/.cargo/git && chown -R vscode:vscode /home/vscode/.cargo
-ENV CARGO_TARGET_DIR=/opt/cargo-target
-
-WORKDIR /tmp
-
-# Slurm (either tarball if SLURM_VERSION is set or from apt if not)
-RUN set -eux; \
-    if [ -n "${SLURM_VERSION}" ]; then \
-      echo "Installing Slurm headers from tarball: ${SLURM_VERSION}"; \
-      wget -q "https://download.schedmd.com/slurm/slurm-${SLURM_VERSION}.tar.bz2"; \
-      tar -xjf "slurm-${SLURM_VERSION}.tar.bz2"; \
-      cd "slurm-${SLURM_VERSION}"; \
-      ./configure --disable-dependency-tracking; \
-      mkdir -p /usr/local/include/slurm; \
-      cp -a slurm/. /usr/local/include/slurm/; \
-      cp -a contribs/spank/. /usr/local/include/slurm/ || true; \
-      if [ -f slurm/slurm_version.h ]; then cp -a slurm/slurm_version.h /usr/local/include/slurm/; fi; \
-    else \
-      echo "Installing Slurm from apt (services + client) and dev headers"; \
-      apt-get update; \
-      apt-get install -y --no-install-recommends \
-        munge \
-        slurmctld slurmd slurm-client \
-        libslurm-dev \
-      ; \
-      rm -rf /var/lib/apt/lists/*; \
-      if [ -d /usr/include/slurm ]; then \
-        mkdir -p /usr/local/include; \
-        ln -sfn /usr/include/slurm /usr/local/include/slurm; \
-      fi; \
-    fi; \
-    rm -rf /tmp/*
-
-ENV CPATH=/usr/local/include:/usr/local/include/slurm:/usr/include
+FROM --platform=linux/amd64 ghcr.io/sarus-suite/cluster-tooling/skybox-dev-base:latest AS base
 
 FROM base AS chef-planner
 
+USER root
 RUN mkdir -p /workspaces/cluster-tooling && chown -R vscode:vscode /workspaces/cluster-tooling
 WORKDIR /workspaces/cluster-tooling
 COPY --chown=vscode:vscode Cargo.toml Cargo.lock ./
@@ -100,6 +22,7 @@ RUN cargo chef prepare --recipe-path recipe.json
 
 FROM base AS chef-builder
 
+USER root
 RUN mkdir -p /workspaces/cluster-tooling && chown -R vscode:vscode /workspaces/cluster-tooling
 WORKDIR /workspaces/cluster-tooling
 COPY --from=chef-planner --chown=vscode:vscode /workspaces/cluster-tooling/recipe.json ./recipe.json

--- a/.devcontainer/ubuntu/devcontainer.json
+++ b/.devcontainer/ubuntu/devcontainer.json
@@ -11,8 +11,6 @@
   "platform": "linux/amd64",
   "runArgs": ["--platform=linux/amd64"],
 
-  "postCreateCommand": "rustup component add rustfmt clippy rust-analyzer || true",
-
   "customizations": {
     "vscode": {
       "extensions": [

--- a/.github/containers/skybox-dev-base/Dockerfile
+++ b/.github/containers/skybox-dev-base/Dockerfile
@@ -39,6 +39,7 @@ ENV RUSTUP_HOME=/home/vscode/.rustup \
 ENV PATH=/home/vscode/.cargo/bin:${PATH}
 
 RUN curl -fsSL https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain stable && \
+    rustup component add rustfmt clippy rust-analyzer && \
     cargo install cargo-chef --locked && \
     rustc -V && cargo -V && cargo chef --version
 

--- a/.github/containers/skybox-dev-base/Dockerfile
+++ b/.github/containers/skybox-dev-base/Dockerfile
@@ -1,0 +1,82 @@
+FROM --platform=linux/amd64 ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Can be set at build time with --build-arg SLURM_VERSION=24.05.8.
+ARG SLURM_VERSION=""
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+      build-essential \
+      gcc g++ make \
+      pkg-config \
+      git \
+      clang llvm \
+      cmake \
+      python3 \
+      wget curl \
+      gawk \
+      bzip2 tar gzip \
+      which \
+      sudo \
+      munge libmunge-dev \
+      hwloc libhwloc-dev \
+      libnuma-dev \
+      ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN set -eux; \
+    if ! id -u vscode >/dev/null 2>&1; then \
+      groupadd -r vscode; \
+      useradd -m -s /bin/bash -g vscode vscode; \
+    fi; \
+    echo "vscode ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/99-vscode; \
+    chmod 0440 /etc/sudoers.d/99-vscode
+
+USER vscode
+ENV RUSTUP_HOME=/home/vscode/.rustup \
+    CARGO_HOME=/home/vscode/.cargo
+ENV PATH=/home/vscode/.cargo/bin:${PATH}
+
+RUN curl -fsSL https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain stable && \
+    cargo install cargo-chef --locked && \
+    rustc -V && cargo -V && cargo chef --version
+
+USER root
+RUN mkdir -p /opt/cargo-target && chown -R vscode:vscode /opt/cargo-target
+RUN mkdir -p /home/vscode/.cargo/git && chown -R vscode:vscode /home/vscode/.cargo
+ENV CARGO_TARGET_DIR=/opt/cargo-target
+
+WORKDIR /tmp
+
+# Slurm (either tarball if SLURM_VERSION is set or from apt if not).
+RUN set -eux; \
+    if [ -n "${SLURM_VERSION}" ]; then \
+      echo "Installing Slurm headers from tarball: ${SLURM_VERSION}"; \
+      wget -q "https://download.schedmd.com/slurm/slurm-${SLURM_VERSION}.tar.bz2"; \
+      tar -xjf "slurm-${SLURM_VERSION}.tar.bz2"; \
+      cd "slurm-${SLURM_VERSION}"; \
+      ./configure --disable-dependency-tracking; \
+      mkdir -p /usr/local/include/slurm; \
+      cp -a slurm/. /usr/local/include/slurm/; \
+      cp -a contribs/spank/. /usr/local/include/slurm/ || true; \
+      if [ -f slurm/slurm_version.h ]; then cp -a slurm/slurm_version.h /usr/local/include/slurm/; fi; \
+    else \
+      echo "Installing Slurm from apt (services + client) and dev headers"; \
+      apt-get update; \
+      apt-get install -y --no-install-recommends \
+        munge \
+        slurmctld slurmd slurm-client \
+        libslurm-dev \
+      ; \
+      rm -rf /var/lib/apt/lists/*; \
+      if [ -d /usr/include/slurm ]; then \
+        mkdir -p /usr/local/include; \
+        ln -sfn /usr/include/slurm /usr/local/include/slurm; \
+      fi; \
+    fi; \
+    rm -rf /tmp/*
+
+ENV CPATH=/usr/local/include:/usr/local/include/slurm:/usr/include
+WORKDIR /workspaces/cluster-tooling
+USER vscode

--- a/.github/workflows/host-tools.yml
+++ b/.github/workflows/host-tools.yml
@@ -17,7 +17,7 @@ on:
         description: parallax release version to fetch
         required: false
         type: string
-        default: "0.10.0"
+        default: "0.10.1"
       podman-static-url:
         description: URL of the podman static tarball to fetch
         required: false

--- a/.github/workflows/skybox-dev-base.yml
+++ b/.github/workflows/skybox-dev-base.yml
@@ -1,0 +1,54 @@
+name: skybox-dev-base
+
+on:
+  push:
+    paths:
+      - .github/containers/skybox-dev-base/Dockerfile
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}/skybox-dev-base
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest
+            type=sha,prefix=git-
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .github/containers/skybox-dev-base
+          file: .github/containers/skybox-dev-base/Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache,mode=max

--- a/.github/workflows/slurm-single-node.yml
+++ b/.github/workflows/slurm-single-node.yml
@@ -24,7 +24,7 @@ jobs:
         id: restore-apt-archives
         uses: actions/cache/restore@v4
         with:
-          path: /var/cache/apt/archives/*.deb
+          path: .ci-cache/apt-archives/*.deb
           key: ${{ runner.os }}-${{ runner.arch }}-apt-archives-slurm-${{ hashFiles('.github/workflows/slurm-single-node.yml') }}
           restore-keys: |
             ${{ runner.os }}-${{ runner.arch }}-apt-archives-slurm-
@@ -164,9 +164,12 @@ jobs:
       - name: Install Slurm + Munge (+ SlurmDBD + MariaDB)
         run: |
           set -euxo pipefail
+          APT_ARCHIVE_CACHE_DIR="${GITHUB_WORKSPACE}/.ci-cache/apt-archives"
+
+          mkdir -p "${APT_ARCHIVE_CACHE_DIR}"
 
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
+          sudo apt-get -o Dir::Cache::archives="${APT_ARCHIVE_CACHE_DIR}" install -y --no-install-recommends \
             munge \
             slurmctld slurmd slurm-client slurmdbd \
             mariadb-server
@@ -557,10 +560,10 @@ jobs:
           podman info
 
       - name: Save apt package archive cache
-        if: steps.restore-apt-archives.outputs.cache-hit != 'true'
+        if: steps.restore-apt-archives.outputs.cache-hit != 'true' && github.event_name == 'push'
         uses: actions/cache/save@v4
         with:
-          path: /var/cache/apt/archives/*.deb
+          path: .ci-cache/apt-archives/*.deb
           key: ${{ steps.restore-apt-archives.outputs.cache-primary-key }}
 
       - name: Fix AppArmor profile for /usr/local/bin/podman

--- a/.github/workflows/slurm-single-node.yml
+++ b/.github/workflows/slurm-single-node.yml
@@ -111,20 +111,32 @@ jobs:
           push: always
           runCmd: |
             set -euxo pipefail
+            ci_phase_start="${SECONDS}"
+            log_phase() {
+              local label="$1"
+              local now="${SECONDS}"
+              echo "::notice::[devcontainer-ci] ${label} (+$((now - ci_phase_start))s)"
+              ci_phase_start="${now}"
+            }
 
             # Building skybox
+            log_phase "starting cargo build -p skybox --release"
             cargo build --locked -p skybox --release
 
             # Build and test sarusctl
+            log_phase "finished skybox build; starting cargo build -p sarusctl --release"
             cargo build --locked -p sarusctl --release
+            log_phase "finished sarusctl build; starting cargo test -p sarusctl --test cli"
             cargo test --locked -p sarusctl --test cli
 
             # Copy artifact into the workspace
+            log_phase "finished sarusctl cli test; copying artifacts"
             mkdir -p dist
             cp -f "${CARGO_TARGET_DIR}/release/libskybox.so" dist/libskybox.so
             cp -f "${CARGO_TARGET_DIR}/release/sarusctl" dist/sarusctl
             ls -l dist/libskybox.so
             ls -l dist/sarusctl
+            log_phase "artifacts copied"
 
       - name: Build libskybox.so in devcontainer (pull request)
         if: github.event_name == 'pull_request'
@@ -136,20 +148,32 @@ jobs:
           push: never
           runCmd: |
             set -euxo pipefail
+            ci_phase_start="${SECONDS}"
+            log_phase() {
+              local label="$1"
+              local now="${SECONDS}"
+              echo "::notice::[devcontainer-ci] ${label} (+$((now - ci_phase_start))s)"
+              ci_phase_start="${now}"
+            }
 
             # Building skybox
+            log_phase "starting cargo build -p skybox --release"
             cargo build --locked -p skybox --release
 
             # Build and test sarusctl
+            log_phase "finished skybox build; starting cargo build -p sarusctl --release"
             cargo build --locked -p sarusctl --release
+            log_phase "finished sarusctl build; starting cargo test -p sarusctl --test cli"
             cargo test --locked -p sarusctl --test cli
 
             # Copy artifact into the workspace
+            log_phase "finished sarusctl cli test; copying artifacts"
             mkdir -p dist
             cp -f "${CARGO_TARGET_DIR}/release/libskybox.so" dist/libskybox.so
             cp -f "${CARGO_TARGET_DIR}/release/sarusctl" dist/sarusctl
             ls -l dist/libskybox.so
             ls -l dist/sarusctl
+            log_phase "artifacts copied"
       
       - name: Install libskybox.so into /usr/lib64/slurm on runner
         shell: bash

--- a/test/smoke/10_podman_rootless.bats
+++ b/test/smoke/10_podman_rootless.bats
@@ -24,6 +24,9 @@ teardown_file() {
   run podman run --rm docker.io/library/alpine:3.20 echo "ok (rootless podman)"
   assert_success
   assert_output --partial "ok (rootless podman)"
+
+  run podman rmi docker.io/library/alpine:3.20
+  assert_success
 }
 
 @test "parallax migrates busybox into a ro store" {
@@ -79,4 +82,20 @@ teardown_file() {
     busybox:latest stat -c '%u %g %n' /bin/sh
   assert_success
   assert_output --regexp '^[0-9]+ [0-9]+ /bin/sh$'
+}
+
+
+@test "podman remove busybox from the parallax ro store" {
+  run "$PARALLAX_BINARY" \
+    --podmanRoot "$PODMAN_ROOT" \
+    --roStoragePath "$RO_STORAGE" \
+    --log-level info \
+    --rmi \
+    --image busybox:latest
+  assert_success
+
+  run "$PODMAN_BINARY" --root "$PODMAN_ROOT" --runroot "$PODMAN_RUNROOT" rmi busybox:latest
+  assert_success
+
+  rm "${RO_STORAGE}/.busybox-ready"
 }

--- a/test/smoke/20_slurm_edf.bats
+++ b/test/smoke/20_slurm_edf.bats
@@ -73,10 +73,6 @@ teardown_file() {
     --roStoragePath "$RO_STORAGE" \
     --log-level info \
     --rmi \
-    --image ubuntu:22.04
-  assert_success
-
-  run "$PODMAN_BINARY" --root "$PODMAN_ROOT" --runroot "$PODMAN_RUNROOT" rmi ubuntu:22.04
+    --image library/ubuntu:22.04
   assert_success
 }
-

--- a/test/smoke/20_slurm_edf.bats
+++ b/test/smoke/20_slurm_edf.bats
@@ -73,10 +73,10 @@ teardown_file() {
     --roStoragePath "$RO_STORAGE" \
     --log-level info \
     --rmi \
-    --image library/ubuntu:22.04
+    --image ubuntu:22.04
   assert_success
 
-  run "$PODMAN_BINARY" --root "$PODMAN_ROOT" --runroot "$PODMAN_RUNROOT" rmi library/ubuntu:22.04
+  run "$PODMAN_BINARY" --root "$PODMAN_ROOT" --runroot "$PODMAN_RUNROOT" rmi ubuntu:22.04
   assert_success
 }
 

--- a/test/smoke/20_slurm_edf.bats
+++ b/test/smoke/20_slurm_edf.bats
@@ -51,3 +51,32 @@ teardown_file() {
   assert_output --partial "/etc/os-release"
   assert_output --partial "/bin/sh"
 }
+
+@test "podman remove busybox from the parallax ro store" {
+  run "$PARALLAX_BINARY" \
+    --podmanRoot "$PODMAN_ROOT" \
+    --roStoragePath "$RO_STORAGE" \
+    --log-level info \
+    --rmi \
+    --image busybox:latest
+  assert_success
+
+  run "$PODMAN_BINARY" --root "$PODMAN_ROOT" --runroot "$PODMAN_RUNROOT" rmi busybox:latest
+  assert_success
+
+  rm "${RO_STORAGE}/.busybox-ready"
+}
+
+@test "podman remove ubuntu from the parallax ro store" {
+  run "$PARALLAX_BINARY" \
+    --podmanRoot "$PODMAN_ROOT" \
+    --roStoragePath "$RO_STORAGE" \
+    --log-level info \
+    --rmi \
+    --image library/ubuntu:22.04
+  assert_success
+
+  run "$PODMAN_BINARY" --root "$PODMAN_ROOT" --runroot "$PODMAN_RUNROOT" rmi library/ubuntu:22.04
+  assert_success
+}
+

--- a/test/smoke/20_slurm_edf.bats
+++ b/test/smoke/20_slurm_edf.bats
@@ -37,9 +37,9 @@ teardown_file() {
 @test "srun with a busybox edf succeeds" {
   smoke_write_edf "busybox" "busybox:latest"
 
-  run srun -p debug -t 3 -A default -J srun-skybox --chdir=/tmp -n 1 --edf=busybox echo "ok :D"
+  run srun -p debug -t 3 -A default -J srun-skybox --chdir=/tmp -n 1 --edf=busybox echo "ok"
   assert_success
-  assert_output "ok :D"
+  assert_output "ok"
 }
 
 @test "srun with an ubuntu edf can stat expected files" {

--- a/test/smoke/test_helper.bash
+++ b/test/smoke/test_helper.bash
@@ -36,12 +36,34 @@ smoke_init_file_env() {
 }
 
 smoke_cleanup_file_env() {
+  local cleanup_rc=0
+  local cleanup_error=""
+  local remaining_entries=""
+  local cleanup_details=""
+
   if [ -n "${SMOKE_TMPDIR:-}" ] && [ -d "${SMOKE_TMPDIR}" ]; then
+    cleanup_error="$(rm -rf "${SMOKE_TMPDIR}" 2>&1)" || cleanup_rc=$?
 
-    rm -rf "${SMOKE_TMPDIR}" 2>/dev/null || true
+    if [ "${cleanup_rc}" -ne 0 ] || [ -d "${SMOKE_TMPDIR}" ]; then
+      if [ -d "${SMOKE_TMPDIR}" ]; then
+        remaining_entries="$(find "${SMOKE_TMPDIR}" -mindepth 1 -maxdepth 1 -printf '%f\n' 2>/dev/null | paste -sd ', ' -)"
+      fi
 
-    if [ -e "${SMOKE_TMPDIR}" ]; then
-      printf 'smoke cleanup incomplete: %s still exists\n' "${SMOKE_TMPDIR}" >&3
+      if [ -n "${cleanup_error}" ]; then
+        cleanup_details="rm exit ${cleanup_rc}: ${cleanup_error}"
+      fi
+      if [ -n "${remaining_entries}" ]; then
+        if [ -n "${cleanup_details}" ]; then
+          cleanup_details="${cleanup_details}; "
+        fi
+        cleanup_details="${cleanup_details}remaining entries: ${remaining_entries}"
+      fi
+
+      if [ -n "${cleanup_details}" ]; then
+        printf 'smoke cleanup failed for %s (%s)\n' "${SMOKE_TMPDIR}" "${cleanup_details}" >&3
+      else
+        printf 'smoke cleanup failed for %s\n' "${SMOKE_TMPDIR}" >&3
+      fi
     fi
   fi
 }

--- a/test/smoke/test_helper.bash
+++ b/test/smoke/test_helper.bash
@@ -38,9 +38,6 @@ smoke_init_file_env() {
 smoke_cleanup_file_env() {
   if [ -n "${SMOKE_TMPDIR:-}" ] && [ -d "${SMOKE_TMPDIR}" ]; then
 
-#    chmod -R u+rwX "${SMOKE_TMPDIR}" 2>/dev/null || true
-#    "${PODMAN_BINARY:-podman}" unshare chmod -R u+rwX "${SMOKE_TMPDIR}" 2>/dev/null || true
-
     rm -rf "${SMOKE_TMPDIR}" 2>/dev/null || true
 
     if [ -e "${SMOKE_TMPDIR}" ]; then

--- a/test/smoke/test_helper.bash
+++ b/test/smoke/test_helper.bash
@@ -38,8 +38,8 @@ smoke_init_file_env() {
 smoke_cleanup_file_env() {
   if [ -n "${SMOKE_TMPDIR:-}" ] && [ -d "${SMOKE_TMPDIR}" ]; then
 
-    chmod -R u+rwX "${SMOKE_TMPDIR}" 2>/dev/null || true
-    "${PODMAN_BINARY:-podman}" unshare chmod -R u+rwX "${SMOKE_TMPDIR}" 2>/dev/null || true
+#    chmod -R u+rwX "${SMOKE_TMPDIR}" 2>/dev/null || true
+#    "${PODMAN_BINARY:-podman}" unshare chmod -R u+rwX "${SMOKE_TMPDIR}" 2>/dev/null || true
 
     rm -rf "${SMOKE_TMPDIR}" 2>/dev/null || true
 

--- a/test/smoke/test_helper.bash
+++ b/test/smoke/test_helper.bash
@@ -88,6 +88,23 @@ smoke_prepare_busybox_ro_store() {
   touch "${RO_STORAGE}/.busybox-ready"
 }
 
+
+smoke_cleanup_busybox_ro_store() {
+  run "$PARALLAX_BINARY" \
+    --podmanRoot "$PODMAN_ROOT" \
+    --roStoragePath "$RO_STORAGE" \
+    --log-level info \
+    --rmi \
+    --image busybox:latest
+  assert_success
+
+  run "$PODMAN_BINARY" --root "$PODMAN_ROOT" --runroot "$PODMAN_RUNROOT" rmi busybox:latest
+  assert_success
+
+  rm "${RO_STORAGE}/.busybox-ready"
+}
+
+
 smoke_write_edf() {
   local name="$1"
   local image="$2"


### PR DESCRIPTION
expands smoke coverage around Podman/parallax image removal and read-only store cleanup, updates expected srun output in the EDF smoke test, and improves smoke cleanup diagnostics to make failures easier to debug.

Host-tools workflow bump from Parallax 0.10.0 to 0.10.1

Speedup of CI from 8min to under 3min by: Adding devcontainer base setup into a dedicated skybox-dev-base image published to GHCR and updates the main devcontainer build to consume it, which should speed up CI and local container setup. It also adds a workflow to build/publish that base image, restores Rust component installation there, and tweaks CI caching/logging in the Slurm single-node workflow for better visibility and more reliable apt archive reuse.

