### PR TITLE
Align profile handling with Container Engine expectations

### DIFF
--- a/crates/podman-driver/src/lib.rs
+++ b/crates/podman-driver/src/lib.rs
@@ -133,8 +133,10 @@ mod commands {
         for dev in &edf.devices {
             cli_opt(&mut cmd, "--device", Some(OsStr::new(dev)));
         }
-        for (key, val) in &edf.env {
-            cli_kv(&mut cmd, "--env", OsStr::new(key), OsStr::new(val));
+        if c_ctx.set_env {
+            for (key, val) in &edf.env {
+                cli_kv(&mut cmd, "--env", OsStr::new(key), OsStr::new(val));
+            }
         }
         for (key, val) in &edf.annotations {
             cli_kv(&mut cmd, "--annotation", OsStr::new(key), OsStr::new(val));

--- a/crates/skybox/src/container.rs
+++ b/crates/skybox/src/container.rs
@@ -226,6 +226,17 @@ pub(crate) fn container_import_env(
     for (key, value) in edf_env.iter() {
         if value == "" {
             unset_keys.push(key);
+            continue;
+        }
+        let overwrite = true;
+
+        match spank.setenv(key, value, overwrite) {
+            Ok(ok) => ok,
+            Err(SpankError::EnvExists(_)) => (),
+            Err(e) => {
+                skybox_log_error!("couldn't set env {key}={value}: {e}");
+                return Err(Box::new(e));
+            }
         }
     }
 

--- a/crates/skybox/src/podman.rs
+++ b/crates/skybox/src/podman.rs
@@ -142,13 +142,14 @@ pub(crate) fn podman_start(
     let runroot = format!("{}/runroot", run.podman_tmp_path);
     let pidfile = format!("{}/pidfile", run.podman_tmp_path);
     //let command = vec!["sleep", "infinity"];
-    let command = vec!["sh", "-c", "kill -STOP $$ ; exit 0"];
+    //let command = vec!["sh", "-c", "kill -STOP $$ ; exit 0"];
+    let command = vec!["sh", "-l", "-c", "exec sh -c 'kill -STOP $$ ; exit 0'"];
 
     let c_ctx = ContainerCtx {
         name: run.name.clone(),
         interactive: false,
         detach: true,
-        set_env: true,
+        set_env: false,
         pidfile: Some(PathBuf::from(pidfile.clone())),
     };
 


### PR DESCRIPTION
* skybox : EDF environment variables are not loaded by podman command line on skybox, but later from /proc/${pid}/environ
* skybox : podman shim has changed to include profile variables in /proc/${pid}/environ
* podman-driver : set_env flag allows to exclude environment variable  from command line